### PR TITLE
Add kobuki ros interfaces 3rd party repo

### DIFF
--- a/thirdparty.repos
+++ b/thirdparty.repos
@@ -31,6 +31,10 @@ repositories:
     type: git
     url: https://github.com/Juancams/kobuki_ros.git
     version: jazzy-devel
+  ThirdParty/kobuki_ros_interfaces:
+    type: git
+    url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+    version: devel
   ThirdParty/openni2_camera:
     type: git
     url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
I think there is one 3rd party repository missing - kobuki_ros_interfaces. Added it to .repos file