### PR TITLE
Added bug warning in kobuki installation in urjc labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ rosdep update
 rosdep install --from-paths src --ignore-src -r -y
 colcon build --symlink-install 
 ```
-
+> **🚨 If you are in the URJC labs, please add the `--packages-skip astra_camera` flag. We hope to have this fixed as soon as possible. 🚨**
+>
 >  If your terminal has crashed or closed while compiling, please try compiling your packages as follows `colcon build --symlink-install --parallel-workers 1` or do so by selecting the package that failed `colcon build --symlink-install --parallel-workers 1 --packages-select <package>`
 > 
 > Also, if you want to prevent it from recompiling that package, add a `COLCON_IGNORE` inside the package


### PR DESCRIPTION
The libusb package is not installed, so compiling ros_astra_camera will fail. Temporary documentation has been added to fix this.